### PR TITLE
아바타 컴포넌트 사이즈 디자인토큰화

### DIFF
--- a/src/entities/user/ui/avatar/Avatar.css.ts
+++ b/src/entities/user/ui/avatar/Avatar.css.ts
@@ -1,5 +1,6 @@
+import { tx } from "@/shared/styles/textStyle.css";
 import { vars } from "@/shared/styles/theme.css";
-import { style } from "@vanilla-extract/css";
+import { style, styleVariants } from "@vanilla-extract/css";
 
 export const container = style({
   display: "flex",
@@ -16,8 +17,43 @@ export const img = style({
   objectFit: "cover",
 });
 
-export const text = style({
-  fontSize: "1.25rem",
+export const baseText = style({
   fontWeight: 400,
+  lineHeight: "160%",
+  letterSpacing: "-0.02em",
   color: vars.color.white,
+});
+
+export const text = styleVariants({
+  20: [
+    baseText,
+    {
+      fontSize: "0.6875rem",
+    },
+  ],
+  26: [baseText, tx.b2_160_rg],
+  32: [
+    baseText,
+    {
+      fontSize: "1rem",
+    },
+  ],
+  38: [
+    baseText,
+    {
+      fontSize: "1.125rem",
+    },
+  ],
+  48: [
+    baseText,
+    {
+      fontSize: "1.5rem",
+    },
+  ],
+  65: [
+    baseText,
+    {
+      fontSize: "2rem",
+    },
+  ],
 });

--- a/src/entities/user/ui/avatar/Avatar.stories.ts
+++ b/src/entities/user/ui/avatar/Avatar.stories.ts
@@ -9,13 +9,17 @@ const meta = {
   },
   tags: ["autodocs"],
   argTypes: {
-    size: { control: "number", description: "아바타 크기" },
+    size: {
+      control: "inline-radio",
+      options: [20, 26, 32, 38, 48, 65],
+      description: "아바타 크기",
+    },
     src: { control: "text", description: "이미지 URL" },
     name: { control: "text", description: "사용자 이름" },
     userId: { control: "number", description: "유저 고유 ID" },
   },
   args: {
-    size: 40,
+    size: 38,
     src: "https://velog.velcdn.com/images/vlmbuyd/post/d85be7e6-5919-4fc3-aba7-f3a38cecb677/image.png",
     name: "User",
     userId: 1,
@@ -25,11 +29,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const WithImage: Story = {
-  args: {
-    size: 48,
-  },
-};
+export const WithImage: Story = {};
 
 export const WithoutImage: Story = {
   args: {

--- a/src/entities/user/ui/avatar/Avatar.tsx
+++ b/src/entities/user/ui/avatar/Avatar.tsx
@@ -5,8 +5,10 @@ import Image from "next/image";
 import * as S from "./Avatar.css";
 import getAvatarStyles from "@/entities/user/lib/styles/getAvatarStyles";
 
+type Size = 20 | 26 | 32 | 38 | 48 | 65;
+
 interface AvatarProps {
-  size?: number; // width, height 크기 (기본값: 40)
+  size?: Size; // width, height 크기 (기본값: 38)
   src?: string; // 이미지 URL
   name?: string; // 사용자 이름 (이미지가 없을 때 첫 글자 표시)
   userId: number; // 유저 고유 ID (배경색 결정용)
@@ -18,7 +20,7 @@ interface AvatarProps {
  * - 배경색은 userId를 기반으로 결정됩니다.
  */
 
-export default function Avatar({ size = 40, src, name, userId }: AvatarProps) {
+export default function Avatar({ size = 38, src, name, userId }: AvatarProps) {
   const [isError, setIsError] = useState<boolean>(false);
   const showImg = !!src && !isError;
   const dynamicStyles = getAvatarStyles(size, userId, showImg);
@@ -41,7 +43,7 @@ export default function Avatar({ size = 40, src, name, userId }: AvatarProps) {
           onError={handleError}
         />
       ) : (
-        <span className={S.text}>{name?.[0]}</span>
+        <span className={S.text[size]}>{name?.[0]}</span>
       )}
     </div>
   );


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 진행한 작업의 주요 내용이나 변경사항

## ✅ 체크리스트

- [x] 주요 기능이 기대한 대로 잘 작동하나요?
- [x] 팀의 코드 컨벤션을 잘 따랐나요?
- [x] 관련 내용을 문서화하여 정리했나요?
- [x] 디버깅용 코드나 사용하지 않는 코드는 제거했나요?
- [x] 리뷰어가 이해하기 쉽도록 필요한 주석을 남겼나요?

## 🧪 테스트 항목

> 완료된 테스트 및 테스트 방법

스토리북 테스트 완

## 💬 기타

### 리뷰어가 알아야 할 사항

동적으로 받던 기존 아바타 컴포넌트 사이즈 값을 `20 | 26 | 32 | 38 | 48 | 65`로 디자인 토큰화 하였고, 각 사이즈별 폰트도 적용하였습니다.
